### PR TITLE
Corrected bug

### DIFF
--- a/chp03_flow/example_03_04_continuousline/sketch.js
+++ b/chp03_flow/example_03_04_continuousline/sketch.js
@@ -12,5 +12,7 @@ function draw() {
   stroke(0);
   
   // Draw a line from previous mouse location to current mouse location.
+  if (pmouseX!=0 && pmouseY!=0) {  //Now there is no default line from left upper corner of browser to current mouse location.
   line(pmouseX, pmouseY, mouseX, mouseY);
+}
 }


### PR DESCRIPTION
Browser loads mouseX and mouseY to 0,0 initially. This causes a line to be drawn from the left upper corner of the browser initially. Now it has been corrected.
