### PR TITLE
Eliminate corner mouseX/Y bug

### DIFF
--- a/chp03_flow/example_03_06_interactive_zoog/sketch.js
+++ b/chp03_flow/example_03_06_interactive_zoog/sketch.js
@@ -17,7 +17,9 @@ function draw() {
   // Set ellipses and rects to CENTER mode
   ellipseMode(CENTER);
   rectMode(CENTER); 
-  
+  //Eliminating corner draw bug
+  if(mouseX!=0 && mouseY!=0)    
+  {
   // Draw Zoog's body
   stroke(0);
   fill(175);
@@ -39,6 +41,7 @@ function draw() {
   // The legs are drawn according to the mouse location and the previous mouse location.
   line(mouseX-10,mouseY+50,pmouseX-10,pmouseY+60);
   line(mouseX+10,mouseY+50,pmouseX+10,pmouseY+60);
+}
 }
 
 function mousePressed() {


### PR DESCRIPTION
Browser initialises mouseX and mouseY to 0 when the page first loads. This causes Zoog body to be present even if we haven't drawn anything yet. A simple if condition eliminates the bug.
